### PR TITLE
fix(brand): enhance robust file moving in sync workflow

### DIFF
--- a/.github/workflows/sync-brand.yml
+++ b/.github/workflows/sync-brand.yml
@@ -68,19 +68,29 @@ jobs:
           # Unzip to a temporary directory first
           unzip -o "$ZIP_FILE" -d temp-unzip
 
+          # The bundle structure is:
+          # bundle/
+          #   favicon-16x16.png
+          #   favicon-32x32.png
+          #   ... (standard files)
+          #   brand/
+          #     bitcraft-og.png
+          #     tokens.css
+          #     ... (brand files)
+
           # Move contents of the 'bundle' directory to temporary holding
           cp -R temp-unzip/bundle/* .
 
-          # Move standard web assets to public/ (overwrite if exists)
-          mv -f site.webmanifest favicon* android-chrome* apple-touch-icon.png public/
+          # 1. Move standard web assets to public/ root
+          # We use a glob that matches the standard files we expect
+          # - favicons, android-chrome, apple-touch-icon, site.webmanifest
+          find . -maxdepth 1 -type f \( -name "favicon*" -o -name "android-chrome*" -o -name "apple-touch-icon.png" -o -name "site.webmanifest" \) -exec mv -f {} public/ \;
 
-          # Move brand specific assets (tokens, OG image) to public/brand/
-          # The zip structure has them in 'brand' subfolder inside bundle
-          # If they were at root of bundle, move them explicitly
-
-          # Check if 'brand' directory exists from unzip (it was bundle/brand)
+          # 2. Move the 'brand' subdirectory contents to public/brand/
+          # The 'brand' folder itself contains the brand-specific assets
           if [ -d "brand" ]; then
              mkdir -p public/brand
+             # Copy contents of brand/ to public/brand/
              cp -R brand/* public/brand/
              rm -rf brand
           fi


### PR DESCRIPTION
## Summary
This PR improves the robustness of the brand sync workflow by:
- Explicitly finding and moving only the expected standard web assets (`favicon*`, `android-chrome*`, etc.) to the `public/` root using `find` instead of broad globs.
- Correctly handling the `brand/` subdirectory by moving its contents to `public/brand/` and cleaning up.
- Adding comments to clarify the expected bundle structure.

This ensures that future updates to the brand bundle are handled predictably, even if the bundle structure varies slightly or contains unexpected files.