### PR TITLE
fix: initialize mobile menu on page load

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -118,6 +118,8 @@ const currentPath = Astro.url.pathname;
   let documentListenersRegistered = false;
   // Track the current button to prevent duplicate click listeners on same element
   let initializedButton: HTMLButtonElement | null = null;
+  // Track initialized mobile links to prevent duplicate click listeners
+  let initializedLinks: WeakSet<Element> = new WeakSet();
 
   function initMobileMenu() {
     const button = document.getElementById("mobile-menu-button") as HTMLButtonElement | null;
@@ -188,10 +190,14 @@ const currentPath = Astro.url.pathname;
     button.addEventListener("click", toggleMenu);
 
     // Close menu when clicking a link (for SPA-like behavior)
+    // Only add listeners to links that haven't been initialized yet
     mobileLinks.forEach((link) => {
-      link.addEventListener("click", () => {
-        closeMenu();
-      });
+      if (!initializedLinks.has(link)) {
+        initializedLinks.add(link);
+        link.addEventListener("click", () => {
+          closeMenu();
+        });
+      }
     });
 
     // Register document-level listeners only once to prevent accumulation


### PR DESCRIPTION
## Summary

Fixes the mobile hamburger menu not responding to clicks.

## Problem

The mobile menu was not working because `initMobileMenu()` was only called via the `astro:page-load` event. This event only fires on initial page load when View Transitions is enabled - which it's not in this project. As a result, the menu was never initialized.

## Solution

- Call `initMobileMenu()` directly for standard page loads (without View Transitions)
- Add `initializedButton` tracking to prevent duplicate initialization when both the direct call and `astro:page-load` fire (future-proofing for when View Transitions is enabled)
- Reset `initializedButton` on `astro:page-load` to properly handle new DOM elements after navigation