### PR TITLE
feat: Add Featured Projects section to homepage

### DIFF
--- a/src/components/FeaturedProjects.astro
+++ b/src/components/FeaturedProjects.astro
@@ -1,0 +1,38 @@
+---
+/**
+ * FeaturedProjects component for displaying featured projects on the homepage
+ * Filters projects by the 'featured' tag and displays up to 3 in a vertical list
+ */
+import { getCollection } from "astro:content";
+import ProjectCard from "./ProjectCard.astro";
+
+const projects = await getCollection("projects");
+
+// Filter projects that have the 'featured' tag
+const featuredProjects = projects
+  .filter((project) => project.data.tags?.includes("featured"))
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 3);
+---
+
+{featuredProjects.length > 0 && (
+  <section class="mt-12">
+    <div class="flex justify-between items-center mb-6">
+      <h2 class="text-2xl font-bold text-dark-olive">Featured Projects</h2>
+      <a
+        href="/projects"
+        class="text-olive-drab hover:text-forest-green transition-colors"
+      >
+        View all projects &rarr;
+      </a>
+    </div>
+
+    <ul class="space-y-6">
+      {featuredProjects.map((project) => (
+        <li>
+          <ProjectCard project={project} />
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/src/content/projects/sample-project.md
+++ b/src/content/projects/sample-project.md
@@ -4,6 +4,7 @@ description: A placeholder project to demonstrate the content collection setup.
 pubDate: 2025-01-23
 repository: https://github.com/example/sample-project
 tags:
+  - featured
   - Astro
   - TypeScript
   - Demo

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import FeaturedProjects from "../components/FeaturedProjects.astro";
 ---
 
 <BaseLayout title="Bitcraft">
@@ -7,7 +8,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <p class="text-lg text-near-black font-sans mb-4">
     Web experiences and tools for <span class="text-forest-green font-bold">Bitcraft</span> and beyond.
   </p>
-  <div class="p-4 bg-off-white rounded-lg border border-olive-drab">
-    <code class="text-sm font-mono text-dark-olive">src/pages/index.astro</code>
-  </div>
+
+  <FeaturedProjects />
 </BaseLayout>


### PR DESCRIPTION
## Summary

- Add `FeaturedProjects.astro` component that filters and displays projects tagged with `featured`
- Update homepage to display the Featured Projects section below the hero content
- Add `featured` tag to sample project to demonstrate functionality

## Details

The Featured Projects section:
- Filters projects by the `featured` tag
- Displays up to 3 projects sorted by date (newest first)
- Uses the existing `ProjectCard` component for consistent styling
- Includes a "View all projects" link to `/projects`
- Only renders when there are featured projects (graceful fallback)

## How to Feature a Project

Add `featured` to the tags array in project frontmatter:

```yaml
tags:
  - featured
  - Other Tag
```